### PR TITLE
Fixed `.env` file not loading from relative path

### DIFF
--- a/YuKitsune.Configuration.Env/YuKitsune.Configuration.Env.Tests/EnvConfigurationSourceTests.cs
+++ b/YuKitsune.Configuration.Env/YuKitsune.Configuration.Env.Tests/EnvConfigurationSourceTests.cs
@@ -7,10 +7,20 @@ namespace YuKitsune.Configuration.Env.Tests
     public class EnvConfigurationSourceTests
     {
         [Fact]
-        public void CanLoadDotPrefixedFiles()
+        public void CanLoadDotPrefixedFiles_FromRootedPath()
         {
-            var tempDirectory = Path.GetTempPath();
-            var envFile = Path.Combine(tempDirectory, ".env.test");
+            var baseDirectory = Path.GetTempPath();
+            var envFile = Path.Combine(baseDirectory, ".env.test");
+            File.WriteAllText(envFile,"var=val");
+
+            var config = new ConfigurationBuilder().AddEnvFile(envFile).Build();
+            Assert.Equal("val", config["var"]);
+        }
+
+        [Fact]
+        public void CanLoadDotPrefixedFiles_FromRelativePath()
+        {
+            var envFile = ".env.test";
             File.WriteAllText(envFile,"var=val");
 
             var config = new ConfigurationBuilder().AddEnvFile(envFile).Build();

--- a/YuKitsune.Configuration.Env/YuKitsune.Configuration.Env/EnvConfigurationSource.cs
+++ b/YuKitsune.Configuration.Env/YuKitsune.Configuration.Env/EnvConfigurationSource.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.FileProviders;
@@ -21,6 +22,9 @@ namespace YuKitsune.Configuration.Env
         /// <returns>An <see cref="EnvConfigurationProvider"/></returns>
         public override IConfigurationProvider Build(IConfigurationBuilder builder)
         {
+            // This is necessary as the default PhysicalFileProvider filters out dot-prefixed files (.env)
+            FileProvider = MakeFileProvider(AppContext.BaseDirectory);
+
             EnsureDefaults(builder);
             return new EnvConfigurationProvider(this);
         }
@@ -42,12 +46,15 @@ namespace YuKitsune.Configuration.Env
                     pathToFile = System.IO.Path.Combine(System.IO.Path.GetFileName(directory), pathToFile);
                     directory = System.IO.Path.GetDirectoryName(directory);
                 }
+
                 if (Directory.Exists(directory))
                 {
-                    FileProvider = new PhysicalFileProvider(directory, ExclusionFilters.System);
+                    FileProvider = MakeFileProvider(directory);
                     Path = pathToFile;
                 }
             }
         }
+
+        IFileProvider MakeFileProvider(string path) => new PhysicalFileProvider(path, ExclusionFilters.System);
     }
 }

--- a/YuKitsune.Configuration.Env/YuKitsune.Configuration.Env/YuKitsune.Configuration.Env.csproj
+++ b/YuKitsune.Configuration.Env/YuKitsune.Configuration.Env/YuKitsune.Configuration.Env.csproj
@@ -4,7 +4,7 @@
         <TargetFramework>net5.0</TargetFramework>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <Authors>Eoin Motherway</Authors>
-        <PackageVersion>1.0.2</PackageVersion>
+        <PackageVersion>1.0.3</PackageVersion>
         <Description>ENV configuration provider implementation for Microsoft.Extensions.Configuration.</Description>
         <PackageTags>dotenv;env;configuration;</PackageTags>
         <PackageProjectUrl>https://github.com/YuKitsune/Configuration.Env</PackageProjectUrl>


### PR DESCRIPTION
The test was passing because it was a rooted path (starting from `/`). Turns out the fix in #3 didn't work for relative paths (`./`)